### PR TITLE
Jasonsturges patch 1

### DIFF
--- a/posix/DefaultPreloader.as
+++ b/posix/DefaultPreloader.as
@@ -81,7 +81,7 @@ public class DefaultPreloader extends MovieClip {
     /**
      * @private
      */
-    protected function initialize() {
+    protected function initialize():void {
         CONFIG::debug { trace("DefaultPreloader::initialize"); }
         try {
             if (!webFS) {
@@ -106,7 +106,7 @@ public class DefaultPreloader extends MovieClip {
     /**
      * @private
      */
-    protected function dispose(event:Event = null) {
+    protected function dispose(event:Event = null):void {
         CONFIG::debug { trace("DefaultPreloader::dispose"); }
         removeListeners();
         removeWebFSListeners();
@@ -115,7 +115,7 @@ public class DefaultPreloader extends MovieClip {
     /**
      * @private
      */
-    protected function removeListeners() {
+    protected function removeListeners():void {
         loaderInfo.removeEventListener(ProgressEvent.PROGRESS, onProgress);
         loaderInfo.removeEventListener(Event.COMPLETE, onPreloaderComplete);
         removeEventListener(Event.ADDED_TO_STAGE, onPreloaderComplete);
@@ -125,7 +125,7 @@ public class DefaultPreloader extends MovieClip {
     /**
      * @private
      */
-    protected function removeWebFSListeners() {
+    protected function removeWebFSListeners():void {
         if (webFS) {
             webFS.removeEventListener(ProgressEvent.PROGRESS, onWebFSProgress);
             webFS.removeEventListener(Event.COMPLETE, onWebFSComplete);

--- a/posix/vfs/URLLoaderVFS.as
+++ b/posix/vfs/URLLoaderVFS.as
@@ -146,7 +146,7 @@ public class URLLoaderVFS extends InMemoryBackingStore {
             }
 
             var paths:Array = newfile.split(" ");
-            var filterFunc:Function = function (path:String, index:int, array:Array) {
+            var filterFunc:Function = function (path:String, index:int, array:Array):void {
                 return (path != "");
             };
             paths = paths.filter(filterFunc);


### PR DESCRIPTION
/posix/vfs/URLLoaderVFS.as(149): col: 84
Add return value of type `void` for anonymous `filterFunc` function to resolve warning.

/posix/DefaultPreloader.as
Add return value of type `void` for the following functions to resolve warning:
- Warning: return value for function 'initialize' has no type declaration.
- Warning: return value for function 'dispose' has no type declaration.
- Warning: return value for function 'removeListeners' has no type declaration.
- Warning: return value for function 'removeWebFSListeners' has no type declaration.