### PR TITLE
Update URLLoaderVFS.as, filterFunc returns bool

### DIFF
--- a/posix/vfs/URLLoaderVFS.as
+++ b/posix/vfs/URLLoaderVFS.as
@@ -146,7 +146,7 @@ public class URLLoaderVFS extends InMemoryBackingStore {
             }
 
             var paths:Array = newfile.split(" ");
-            var filterFunc:Function = function (path:String, index:int, array:Array):void {
+            var filterFunc:Function = function (path:String, index:int, array:Array):Boolean {
                 return (path != "");
             };
             paths = paths.filter(filterFunc);


### PR DESCRIPTION
This is errata from my previous commit to resolve warnings, which accidentally broke the master branch.

`filterFunc` returns `Boolean`, not `void`.

Sorry about that - I think I have my compiler issues resolved to avoid breaking master build in the future.
